### PR TITLE
Fixing bug that meant printing a vector matching expression with matc…

### DIFF
--- a/src/PromQL.Parser/Printer.cs
+++ b/src/PromQL.Parser/Printer.cs
@@ -173,7 +173,7 @@ namespace PromQL.Parser
                 _sb.Append(vm.MatchCardinality.ToPromQl());
             }
 
-            if (vm.Include.Length > 0)
+            if (vm.Include.Length > 0 || vm.MatchCardinality != VectorMatching.DefaultMatchCardinality)
             {
                 if (_sb.Length > 0)
                     _sb.Append(" ");

--- a/tests/PromQL.Parser.Tests/PrinterTests.cs
+++ b/tests/PromQL.Parser.Tests/PrinterTests.cs
@@ -136,7 +136,7 @@ namespace PromQL.Parser.Tests
                 false,
                 ImmutableArray<string>.Empty,
                 false
-            )).Should().Be("group_right");
+            )).Should().Be("group_right ()");
         }
         
         [Test]


### PR DESCRIPTION
…her labels would incorrectly not include empty parenthesis for group_right/ group_left