### PR TITLE
Update publish-nuget-packages.yaml

### DIFF
--- a/.github/workflows/publish-nuget-packages.yaml
+++ b/.github/workflows/publish-nuget-packages.yaml
@@ -18,4 +18,4 @@ jobs:
         VERSION="${arrTag[2]}"
         echo "Version: $VERSION"
         dotnet pack src/PromQL.Parser --include-symbols -c "Release" -p:Version=$VERSION  --output "build/"
-        dotnet nuget push "build/PromQL.Parser.*.symbols.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s "https://api.nuget.org/v3/index.json" -n true
+        dotnet nuget push "build/PromQL.Parser.*.symbols.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s "https://api.nuget.org/v3/index.json" --no-symbols


### PR DESCRIPTION
`-n` doesn't accept arguments anymore. Used `--no-symbols` to make the argument intent obvious.